### PR TITLE
Add Brianna to list of Steering Council Members

### DIFF
--- a/src/data/steering-council-members.js
+++ b/src/data/steering-council-members.js
@@ -11,5 +11,6 @@ export const SteeringCouncilMembers = [
   { name: 'Thomas Moore', github: 'Thomas-Moore-Creative' },
   { name: 'James Munroe', github: 'jmunroe' },
   { name: 'Tina Odaka', github: 'tinaok' },
+  { name: 'Brianna Pagan', github: 'briannapagan' },
   { name: 'Rich Signell', github: 'rsignell-usgs' },
 ]


### PR DESCRIPTION
Looks like Brianna was missing from the Steering Council Membership acoording to https://github.com/pangeo-data/governance/blob/main/steering_council_membership.md - one of these two sources must be wrong.